### PR TITLE
Fix duplicated command line

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -38,7 +38,7 @@ parts:
 
 apps:
   github-desktop:
-    command: # Correct the TMPDIR path for Chromium Framework/Electron to
+    # Correct the TMPDIR path for Chromium Framework/Electron to
     # ensure libappindicator has readable resources.
     command: env TMPDIR=$XDG_RUNTIME_DIR PATH=/usr/local/bin:${PATH} ${SNAP}/bin/desktop-launch $SNAP/opt/GithubDesktop/desktop
     desktop: usr/share/applications/desktop.desktop


### PR DESCRIPTION
This removed duplicated `command` line from snapcraft.yaml which should fix https://github.com/canonical-websites/build.snapcraft.io/issues/875